### PR TITLE
Add RDF Messages Interoperability Tests

### DIFF
--- a/.github/workflows/build-spec.yml
+++ b/.github/workflows/build-spec.yml
@@ -20,6 +20,8 @@ jobs:
             destination: index.html
           - source: spec/messages.bs
             destination: spec/messages.html
+          - source: spec/messages-tests.bs
+            destination: spec/messages-tests.html
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Currently, this repository contains the following specifications:
 
 - RDF Messages – [source code](spec/messages.bs), [published version](https://w3c-cg.github.io/rsp/spec/messages)
     - Defines the base concepts of RDF Messages, RDF Message Streams, and RDF Message Logs.
+- RDF Messages Tests – [source code](spec/messages-tests.bs), [published version](https://w3c-cg.github.io/rsp/spec/messages-tests)
+    - Provides interoperability tests for parsers and serializers that support RDF Message Logs.
 
 Additionally, there is the [index.bs](index.bs) file that lists the specifications ([published version](https://w3c-cg.github.io/rsp)).
 

--- a/spec/messages-tests.bs
+++ b/spec/messages-tests.bs
@@ -11,7 +11,7 @@ Repository: https://github.com/w3c-cg/rsp
 Abstract: Tests for parsers and serializers with message support in various RDF serializations.
 </pre>
 
-# RDF Messages Interoperability Tests
+# RDF Messages Interoperability Tests # {#rdf-messages-interoperability-tests}
 
 This document proposes interoperability tests for implementations that support RDF Message Logs for different serializations.
 
@@ -28,9 +28,9 @@ Message delimiters are message-level syntax. They MUST only occur where the unde
 Serializers should produce RDF Message Logs that round-trip to the same message sequence and the same quads per message. Conformance tests should not require a serializer to choose a specific delimiter spelling when more than one delimiter spelling is supported by the target syntax.
 
 
-## Parsing Tests for Turtle, TriG, N-Triples, and N-Quads
+## Parsing Tests for Turtle, TriG, N-Triples, and N-Quads ## {#parsing-tests-turtle-trig-n-triples-n-quads}
 
-### 1. Single Message Without Delimiter
+### Single Message Without Delimiter ### {#single-message-without-delimiter}
 
 Input:
 
@@ -46,7 +46,7 @@ Message 1:
   <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
 ```
 
-### 2. Two Messages With `MESSAGE`
+### Two Messages With `MESSAGE` ### {#two-messages-with-message}
 
 Input:
 
@@ -67,7 +67,7 @@ Message 2:
   <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
 ```
 
-### 3. Two Messages With `@message .`
+### Two Messages With `@message .` ### {#two-messages-with-at-message}
 
 Input:
 
@@ -90,7 +90,7 @@ Message 2:
   <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
 ```
 
-### 4. Empty First Message
+### Empty First Message ### {#empty-first-message}
 
 Input:
 
@@ -110,7 +110,7 @@ Message 2:
   <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
 ```
 
-### 5. Empty Message Between Non-Empty Messages
+### Empty Message Between Non-Empty Messages ### {#empty-message-between-non-empty-messages}
 
 Input:
 
@@ -135,7 +135,7 @@ Message 3:
   <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
 ```
 
-### 6. Final Delimiter Does Not Create Extra Empty Message
+### Final Delimiter Does Not Create Extra Empty Message ### {#final-delimiter-does-not-create-extra-empty-message}
 
 Input:
 
@@ -152,11 +152,11 @@ Message 1:
   <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
 ```
 
-### 7. N-Quads Messages Preserve Graph Names
+### N-Quads Messages Preserve Graph Names ### {#n-quads-messages-preserve-graph-names}
 
 Input:
 
-```nquads
+```text
 VERSION "1.2-messages"
 <http://example.org/s1> <http://example.org/p> <http://example.org/o1> <http://example.org/g1> .
 MESSAGE
@@ -173,11 +173,11 @@ Message 2:
   <http://example.org/s2> <http://example.org/p> <http://example.org/o2> <http://example.org/g2> .
 ```
 
-### 8. Message With Default Graph And Named Graph Quads
+### Message With Default Graph And Named Graph Quads ### {#message-with-default-graph-and-named-graph-quads}
 
 Input:
 
-```trig
+```turtle
 VERSION "1.2-messages"
 PREFIX ex: <http://example.org/>
 
@@ -202,7 +202,7 @@ Message 2:
   <http://example.org/s4> <http://example.org/p> <http://example.org/o4> .
 ```
 
-### 9. Blank Node Labels Are Scoped Per Message
+### Blank Node Labels Are Scoped Per Message ### {#blank-node-labels-are-scoped-per-message}
 
 Input:
 
@@ -223,7 +223,7 @@ The two blank nodes must not be the same RDF term.
 
 This test must be performed on one continuous input string or stream, not by creating two independent parser instances.
 
-### 10. Repeated Prefixes Across Messages
+### Repeated Prefixes Across Messages ### {#repeated-prefixes-across-messages}
 
 Input:
 
@@ -246,11 +246,11 @@ Message 2:
   <http://example.org/two/s> <http://example.org/two/p> <http://example.org/two/o> .
 ```
 
-### 11. Message Boundary After A Graph Block
+### Message Boundary After A Graph Block ### {#message-boundary-after-a-graph-block}
 
 Input:
 
-```trig
+```turtle
 VERSION "1.2-messages"
 <http://example.org/g> {
   <http://example.org/a> <http://example.org/b> <http://example.org/c> .
@@ -269,7 +269,7 @@ Message 2:
   <http://example.org/d> <http://example.org/e> <http://example.org/f> .
 ```
 
-## Serialization Tests for Turtle, TriG, N-Triples, and N-Quads
+## Serialization Tests for Turtle, TriG, N-Triples, and N-Quads ## {#serialization-tests-turtle-trig-n-triples-n-quads}
 
 Given a sequence of RDF Messages, a serializer should write a document that can be parsed back into the same sequence of messages and quads.
 
@@ -321,9 +321,9 @@ Message 2:
   <http://example.org/d> <http://example.org/e> <http://example.org/f> <http://example.org/g> .
 ```
 
-## Error Tests
+## Error Tests ## {#error-tests}
 
-### 1. Message Delimiter Without Message Support
+### Message Delimiter Without Message Support ### {#message-delimiter-without-message-support}
 
 If a parser is not in RDF Messages mode and encounters a message delimiter, it must reject the document.
 
@@ -340,7 +340,7 @@ Expected result:
 Parse error.
 ```
 
-### 2. `@message` Without Trailing Dot
+### `@message` Without Trailing Dot ### {#at-message-without-trailing-dot}
 
 Input:
 
@@ -356,13 +356,13 @@ Expected result:
 Parse error.
 ```
 
-### 3. Message Delimiter Inside An Open Graph Block
+### Message Delimiter Inside An Open Graph Block ### {#message-delimiter-inside-an-open-graph-block}
 
 A message delimiter must not be accepted inside an open graph block. It must be rejected instead of being interpreted as splitting the graph block across two messages.
 
 Input:
 
-```trig
+```turtle
 VERSION "1.2-messages"
 <http://example.org/g> {
   <http://example.org/a> <http://example.org/b> <http://example.org/c> .
@@ -376,4 +376,3 @@ Expected result:
 ```text
 Parse error.
 ```
-

--- a/spec/messages-tests.bs
+++ b/spec/messages-tests.bs
@@ -1,8 +1,21 @@
+<pre class='metadata'>
+Title: RDF Messages Tests
+Shortname: RDF-M-tests
+Level: 1
+Status: LD
+Markup Shorthands: markdown yes
+URL: https://w3c-cg.github.io/rsp/spec/messages-tests
+Editor: Pieter Colpaert, https://pietercolpaert.be
+Editor: Piotr Sowiński, NeverBlink https://www.neverblink.eu/, https://ostrzyciel.eu/
+Repository: https://github.com/w3c-cg/rsp
+Abstract: Tests for parsers and serializers with message support in various RDF serializations.
+</pre>
+
 # RDF Messages Interoperability Tests
 
-This document proposes interoperability tests for implementations that support RDF Message Logs for Turtle, TriG, N-Triples, and N-Quads.
+This document proposes interoperability tests for implementations that support RDF Message Logs for different serializations.
 
-Implementations MUST provide conformance tests for RDF Message Logs that verify message-level behavior.
+Implementations of parsers and serializers MUST provide conformance tests for RDF Message Logs that verify message-level behavior.
 
 An RDF Message Log parser MUST expose a message-level interface that emits one RDF Dataset per completed message.
 
@@ -15,7 +28,7 @@ Message delimiters are message-level syntax. They MUST only occur where the unde
 Serializers should produce RDF Message Logs that round-trip to the same message sequence and the same quads per message. Conformance tests should not require a serializer to choose a specific delimiter spelling when more than one delimiter spelling is supported by the target syntax.
 
 
-## Parsing Tests
+## Parsing Tests for Turtle, TriG, N-Triples, and N-Quads
 
 ### 1. Single Message Without Delimiter
 
@@ -256,7 +269,7 @@ Message 2:
   <http://example.org/d> <http://example.org/e> <http://example.org/f> .
 ```
 
-## Serialization Tests
+## Serialization Tests for Turtle, TriG, N-Triples, and N-Quads
 
 Given a sequence of RDF Messages, a serializer should write a document that can be parsed back into the same sequence of messages and quads.
 

--- a/spec/messages-tests.md
+++ b/spec/messages-tests.md
@@ -1,0 +1,366 @@
+# RDF Messages Interoperability Tests
+
+This document proposes interoperability tests for implementations that support RDF Message Logs for Turtle, TriG, N-Triples, and N-Quads.
+
+Implementations MUST provide conformance tests for RDF Message Logs that verify message-level behavior.
+
+An RDF Message Log parser MUST expose a message-level interface that emits one RDF Dataset per completed message.
+
+A message is completed when a message delimiter or the end of the input is encountered. Empty messages MUST be preserved when they occur before the first triple or quad, or between two delimiters. A trailing delimiter after a non-empty message MUST finalize that message and MUST not by itself create an additional empty trailing message.
+
+Blank node identifiers in RDF Message Logs MUST be scoped to the message in which they occur. Therefore, if the same blank node label appears in two different messages in the same input stream, the parser MUST produce two distinct blank nodes. This requirement applies even when the entire RDF Message Log is parsed from one continuous input string or stream by one parser instance.
+
+Message delimiters are message-level syntax. They MUST only occur where the underlying RDF syntax permits directives or top-level statements, and MUST not occur inside an open graph block. A delimiter encountered inside a graph block MUST be a parse error.
+
+Serializers should produce RDF Message Logs that round-trip to the same message sequence and the same quads per message. Conformance tests should not require a serializer to choose a specific delimiter spelling when more than one delimiter spelling is supported by the target syntax.
+
+
+## Parsing Tests
+
+### 1. Single Message Without Delimiter
+
+Input:
+
+```turtle
+VERSION "1.2-messages"
+<http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+```
+
+### 2. Two Messages With `MESSAGE`
+
+Input:
+
+```turtle
+VERSION "1.2-messages"
+<http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+MESSAGE
+<http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+Message 2:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+### 3. Two Messages With `@message .`
+
+Input:
+
+```turtle
+@version "1.2-messages" .
+@prefix ex: <http://example.org/> .
+
+ex:s1 ex:p ex:o1 .
+@message .
+ex:s2 ex:p ex:o2 .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+Message 2:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+### 4. Empty First Message
+
+Input:
+
+```turtle
+VERSION "1.2-messages"
+MESSAGE
+<http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  empty
+
+Message 2:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+```
+
+### 5. Empty Message Between Non-Empty Messages
+
+Input:
+
+```turtle
+VERSION "1.2-messages"
+<http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+MESSAGE
+MESSAGE
+<http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+Message 2:
+  empty
+
+Message 3:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+### 6. Final Delimiter Does Not Create Extra Empty Message
+
+Input:
+
+```turtle
+VERSION "1.2-messages"
+<http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+MESSAGE
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+```
+
+### 7. N-Quads Messages Preserve Graph Names
+
+Input:
+
+```nquads
+VERSION "1.2-messages"
+<http://example.org/s1> <http://example.org/p> <http://example.org/o1> <http://example.org/g1> .
+MESSAGE
+<http://example.org/s2> <http://example.org/p> <http://example.org/o2> <http://example.org/g2> .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> <http://example.org/g1> .
+
+Message 2:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> <http://example.org/g2> .
+```
+
+### 8. Message With Default Graph And Named Graph Quads
+
+Input:
+
+```trig
+VERSION "1.2-messages"
+PREFIX ex: <http://example.org/>
+
+ex:s1 ex:p ex:o1 .
+ex:g {
+  ex:s2 ex:p ex:o2 .
+  ex:s3 ex:p ex:o3 .
+}
+MESSAGE
+ex:s4 ex:p ex:o4 .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> <http://example.org/g> .
+  <http://example.org/s3> <http://example.org/p> <http://example.org/o3> <http://example.org/g> .
+
+Message 2:
+  <http://example.org/s4> <http://example.org/p> <http://example.org/o4> .
+```
+
+### 9. Blank Node Labels Are Scoped Per Message
+
+Input:
+
+```turtle
+VERSION "1.2-messages"
+_:b0 <http://example.org/p> <http://example.org/o1> .
+MESSAGE
+_:b0 <http://example.org/p> <http://example.org/o2> .
+```
+
+Expected result:
+
+```text
+Message 1 contains one quad whose subject is a blank node.
+Message 2 contains one quad whose subject is a blank node.
+The two blank nodes must not be the same RDF term.
+```
+
+This test must be performed on one continuous input string or stream, not by creating two independent parser instances.
+
+### 10. Repeated Prefixes Across Messages
+
+Input:
+
+```turtle
+VERSION "1.2-messages"
+PREFIX ex: <http://example.org/one/>
+ex:s ex:p ex:o .
+MESSAGE
+PREFIX ex: <http://example.org/two/>
+ex:s ex:p ex:o .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/one/s> <http://example.org/one/p> <http://example.org/one/o> .
+
+Message 2:
+  <http://example.org/two/s> <http://example.org/two/p> <http://example.org/two/o> .
+```
+
+### 11. Message Boundary After A Graph Block
+
+Input:
+
+```trig
+VERSION "1.2-messages"
+<http://example.org/g> {
+  <http://example.org/a> <http://example.org/b> <http://example.org/c> .
+}
+MESSAGE
+<http://example.org/d> <http://example.org/e> <http://example.org/f> .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/a> <http://example.org/b> <http://example.org/c> <http://example.org/g> .
+
+Message 2:
+  <http://example.org/d> <http://example.org/e> <http://example.org/f> .
+```
+
+## Serialization Tests
+
+Given a sequence of RDF Messages, a serializer should write a document that can be parsed back into the same sequence of messages and quads.
+
+Serializers may choose the concrete message delimiter supported by their syntax. These tests should not assert whether `@message .` or `MESSAGE` was used.
+
+Round-trip input messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+Message 2:
+  empty
+
+Message 3:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+Expected result after serializing and parsing the output:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+Message 2:
+  empty
+
+Message 3:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+Round-trip input messages with named graph quads:
+
+```text
+Message 1:
+  <http://example.org/a> <http://example.org/b> <http://example.org/c> <http://example.org/g> .
+
+Message 2:
+  <http://example.org/d> <http://example.org/e> <http://example.org/f> <http://example.org/g> .
+```
+
+Expected result after serializing and parsing the output:
+
+```text
+Message 1:
+  <http://example.org/a> <http://example.org/b> <http://example.org/c> <http://example.org/g> .
+
+Message 2:
+  <http://example.org/d> <http://example.org/e> <http://example.org/f> <http://example.org/g> .
+```
+
+## Error Tests
+
+### 1. Message Delimiter Without Message Support
+
+If a parser is not in RDF Messages mode and encounters a message delimiter, it must reject the document.
+
+Input:
+
+```turtle
+<http://example.org/s> <http://example.org/p> <http://example.org/o> .
+MESSAGE
+```
+
+Expected result:
+
+```text
+Parse error.
+```
+
+### 2. `@message` Without Trailing Dot
+
+Input:
+
+```turtle
+VERSION "1.2-messages"
+<http://example.org/s> <http://example.org/p> <http://example.org/o> .
+@message <http://example.org/invalid>
+```
+
+Expected result:
+
+```text
+Parse error.
+```
+
+### 3. Message Delimiter Inside An Open Graph Block
+
+A message delimiter must not be accepted inside an open graph block. It must be rejected instead of being interpreted as splitting the graph block across two messages.
+
+Input:
+
+```trig
+VERSION "1.2-messages"
+<http://example.org/g> {
+  <http://example.org/a> <http://example.org/b> <http://example.org/c> .
+@message
+  <http://example.org/d> <http://example.org/e> <http://example.org/f> .
+}
+```
+
+Expected result:
+
+```text
+Parse error.
+```
+

--- a/spec/messages-tests.md
+++ b/spec/messages-tests.md
@@ -353,7 +353,7 @@ Input:
 VERSION "1.2-messages"
 <http://example.org/g> {
   <http://example.org/a> <http://example.org/b> <http://example.org/c> .
-@message
+MESSAGE
   <http://example.org/d> <http://example.org/e> <http://example.org/f> .
 }
 ```

--- a/spec/messages.bs
+++ b/spec/messages.bs
@@ -15,6 +15,8 @@ Abstract: Concepts and abstract data model for RDF Messages
 
 This specification defines the concepts of RDF Messages, RDF Message Streams, and RDF Message Logs, as well as the syntax for serializing RDF Message Logs in various RDF serialization formats.
 
+The companion document [RDF Messages Tests](spec/messages-tests.bs) defines interoperability tests for RDF Message Logs and supported serialization formats.
+
 In this document, we are discussing *message-level* streaming, where streams are sequences of discrete messages – each message may contain multiple RDF triples or quads. This is in contrast to *triple-* or *quad-level* streaming of RDF data, where streams are sequences of individual RDF triples or quads. For quad-level streaming, please refer to, for example: [[!n-quads]], [[!n-triples]], and [[!json-ld11-streaming]].
 
 Note: Quad-level streaming is complementary to message-level streaming, and both can be used together. This is the case, for example, in the [Jelly](https://w3id.org/jelly/) serialization format, as well as some of the formats proposed in [[#rdf-message-logs-serialization]].


### PR DESCRIPTION
This document outlines interoperability tests for RDF Message Logs, including parsing, serialization, and error handling scenarios. It specifies requirements for message delimiters, blank node scoping, and expected outcomes for various input cases.

I generated from the tests that were needed in the implementation in RDFJS/N3.js: https://github.com/rdfjs/N3.js/pull/586