### PR TITLE
Proposal for NDJSON-LD

### DIFF
--- a/spec/messages-tests.bs
+++ b/spec/messages-tests.bs
@@ -269,6 +269,105 @@ Message 2:
   <http://example.org/d> <http://example.org/e> <http://example.org/f> .
 ```
 
+## Parsing Tests for NDJSON-LD ## {#parsing-tests-json-ld-message-logs}
+
+In these tests, each input line is one JSON object. Context messages update parser state but do not emit RDF messages. A parser maintains an active context that is updated by context messages.
+
+### Context Message Followed By Data Message ### {#context-message-followed-by-data-message}
+
+Input:
+
+```json
+{"@context": "https://schema.org/"}
+{"@type": "Product", "name": "Hairdryer DRY 2000", "color": "red"}
+```
+
+Expected messages:
+
+```text
+Message 1:
+  RDF dataset obtained by interpreting the second JSON object with @context = "https://schema.org/".
+```
+
+### Empty Message Does Not Change Active Context ### {#empty-message-does-not-change-active-context}
+
+Input:
+
+```json
+{"@context": "https://schema.org/"}
+{}
+{"@type": "Product", "name": "27-inch 4K Monitor 2700P", "color": "black"}
+```
+
+Expected messages:
+
+```text
+Message 1:
+  empty
+
+Message 2:
+  RDF dataset obtained by interpreting the third JSON object with @context = "https://schema.org/".
+```
+
+### Context Switch Applies To Subsequent Data Messages ### {#context-switch-applies-to-subsequent-data-messages}
+
+Input:
+
+```json
+{"@context": "https://schema.org/"}
+{"@type": "Product", "name": "Hairdryer DRY 2000", "color": "red"}
+{"@context": "https://example.org/other-vocab/"}
+{"@type": "OtherType", "name": "Piotr"}
+```
+
+Expected messages:
+
+```text
+Message 1:
+  RDF dataset obtained by interpreting the second JSON object with @context = "https://schema.org/".
+
+Message 2:
+  RDF dataset obtained by interpreting the fourth JSON object with @context = "https://example.org/other-vocab/".
+```
+
+### Data Message With Local `@context` Is Wrapped With Active Context ### {#data-message-context-is-combined-with-active-context}
+
+Input:
+
+```json
+{"@context": {"ex": "https://example.org/base/", "name": "ex:baseName"}}
+{"@context": {"label": "ex:label"}, "@type": "ex:Thing", "name": "Alice", "label": "A"}
+{"@type": "ex:Thing", "name": "Bob"}
+```
+
+Expected messages:
+
+```text
+Message 1:
+  RDF dataset obtained by processing the effective JSON-LD document:
+  {"@context": {"ex": "https://example.org/base/", "name": "ex:baseName"}, "@graph": {"@context": {"label": "ex:label"}, "@type": "ex:Thing", "name": "Alice", "label": "A"}}
+
+Message 2:
+  RDF dataset obtained by processing the effective JSON-LD document:
+  {"@context": {"ex": "https://example.org/base/", "name": "ex:baseName"}, "@graph": {"@type": "ex:Thing", "name": "Bob"}}
+  The local @context from line 2 does not change the active context C for subsequent messages.
+```
+
+### Data Message Without Prior Context Is Allowed ### {#data-message-without-prior-context-is-allowed}
+
+Input:
+
+```json
+{"@id": "https://example.org/p1", "@type": "https://example.org/Product"}
+```
+
+Expected messages:
+
+```text
+Message 1:
+  RDF dataset obtained by interpreting the JSON object as regular JSON-LD, without a stream-level active context.
+```
+
 ## Serialization Tests for Turtle, TriG, N-Triples, and N-Quads ## {#serialization-tests-turtle-trig-n-triples-n-quads}
 
 Given a sequence of RDF Messages, a serializer should write a document that can be parsed back into the same sequence of messages and quads.

--- a/spec/messages.bs
+++ b/spec/messages.bs
@@ -411,18 +411,46 @@ ex:person ex:says "Goodbye, world!" .
 
 Issue: This discussion is preliminary, yet on-going, in the JSON-LD group itself with a proposal called [newline delimited JSON-LD](https://github.com/json-ld/ndjson-ld/issues/1). We propose that that specification becomes the preferred way of adding messages support in JSON-LD. It is [already implemented in some libraries](https://github.com/eclipse-rdf4j/rdf4j/issues/2840) and it is already being used in some projects.
 
-We propose to use the [unofficial NDJSON-LD format](https://github.com/json-ld/ndjson-ld) as the serialization format for [=RDF Message Logs=] in JSON-LD. In [NDJSON](https://github.com/ndjson/ndjson-spec), multiple JSON objects are concatenated together, with each object being separated by a newline character (`\n`). NDJSON-LD simply applies this format to JSON-LD documents, where each each line corresponds to an [=RDF Message=].
+In the [NDJSON](https://github.com/ndjson/ndjson-spec) spec, multiple JSON objects are concatenated together, with each object being separated by a newline character (`\n`). Our proposal for NDJSON-LD applies this format to JSON-LD documents.
+
+Each line in the log MUST be exactly one JSON object. Blank lines are not allowed.
+
+To avoid repeating `@context` in every message while still keeping the format simple, a message in NDJSON-LD MUST be one of the following:
+
+1. A **context message**: a JSON object with exactly one key, `@context`.
+2. An **empty message**: the empty JSON object (`{}`).
+3. A **data message**: any other JSON object that can be interpreted as RDF, optionally using the most recently seen context message. A data message MAY include its own `@context`.
+
+Parsers MUST process NDJSON-LD as follows:
+
+1. Maintain a variable `C` (the active context), initially unset.
+2. For each parsed line `L`, where `L` is a JSON object:
+  1. If `L` is `{}` (an empty message), emit one empty [=RDF Message=]. The value of `C` is unchanged.
+  2. Else if `L` has exactly one key `@context` (a context message), set `C = L["@context"]`.
+  3. Else (a data message):
+    1. Create an effective JSON-LD document `D` from `L` as follows:
+      1. If `C` is unset, set `D = L`.
+      2. If `C` is set, set `D = {"@context": C, "@graph": L}`.
+    2. Expand and convert `D` to RDF, and emit the resulting [=RDF Message=].
+
+Context messages may appear anywhere in the stream and overwrite the previously active context. This allows context changes over time while keeping data messages compact.
+
+Note: When a data message includes `@context`, it is treated as part of the message data and wrapped as `{"@context": C, "@graph": L}`, where the message's local `@context` is processed as part of the graph relative to the envelope context `C`. The local `@context` in the message does not change `C` for subsequent messages.
 
 Issue: What should be the content type for this format? RDF4J currently uses `application/x-ld+ndjson` – [see the pull request](https://github.com/eclipse-rdf4j/rdf4j/pull/2845).
 
 <figure>
 <div class="example" highlight="json">
 ```json
-{"@context": "https://schema.org/", "@type": "Product", "name": "Hairdryer DRY 2000", "color": "red"}
-{"@context": "https://schema.org/", "@type": "Product", "name": "27-inch 4K Monitor 2700P", "color": "black"}
+{"@context": "https://schema.org/"}
+{"@type": "Product", "name": "Hairdryer DRY 2000", "color": "red"}
+{}
+{"@type": "Product", "name": "27-inch 4K Monitor 2700P", "color": "black"}
+{"@context": "https://example.org/other-vocab/"}
+{"@type": "OtherType", "name": "Switched context"}
 ```
 </div>
-<figcaption>Example of an [=RDF Message Log=] in the NDJSON-LD serialization format.</figcaption>
+<figcaption>Example of an [=RDF Message Log=] in the NDJSON-LD serialization format with a context message, an empty message, and data messages interpreted using the active context.</figcaption>
 </figure>
 
 ## YAML-LD ## {#yaml-ld}


### PR DESCRIPTION
NDJSON-LD should be the implementation of RDF Messages for JSON-LD. We propose it here first, with the idea that when we like our final proposal, that we propose it as the solution for https://json-ld.github.io/ndjson-ld/ in the JSON-LD group. 

Fix #17 and fix #25