### PR TITLE
Discovering RDF Messages support in live streams

### DIFF
--- a/spec/messages-tests.bs
+++ b/spec/messages-tests.bs
@@ -13,9 +13,9 @@ Abstract: Tests for parsers and serializers with message support in various RDF 
 
 # RDF Messages Interoperability Tests # {#rdf-messages-interoperability-tests}
 
-This document proposes interoperability tests for implementations that support RDF Message Logs for different serializations.
+This document proposes interoperability tests for implementations that support RDF Message Logs and RDF Message live streams for different serializations.
 
-Implementations of parsers and serializers MUST provide conformance tests for RDF Message Logs that verify message-level behavior.
+Implementations of parsers, serializers, and live stream adapters MUST provide conformance tests that verify message-level behavior.
 
 An RDF Message Log parser MUST expose a message-level interface that emits one RDF Dataset per completed message.
 
@@ -27,6 +27,203 @@ Message delimiters are message-level syntax. They MUST only occur where the unde
 
 Serializers should produce RDF Message Logs that round-trip to the same message sequence and the same quads per message. Conformance tests should not require a serializer to choose a specific delimiter spelling when more than one delimiter spelling is supported by the target syntax.
 
+
+## Message Stream Discovery Tests ## {#message-stream-discovery-tests}
+
+These tests apply to adapters that expose protocol messages as RDF Messages.
+
+### Server-Sent Events With JSON-LD Context Link ### {#sse-json-ld-context-link}
+
+Stream metadata:
+
+```http
+Content-Type: text/event-stream
+Link: <https://example.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+RDF-Message-Content-Type: application/ld+json
+```
+
+The context document at `https://example.org/context.jsonld` is:
+
+```json
+{"@context":{"ex":"http://example.org/","p":{"@id":"http://example.org/p","@type":"@id"}}}
+```
+
+Input events:
+
+```text
+event: rdf-message
+data: {"@id":"ex:s1","p":"ex:o1"}
+
+event: rdf-message
+data: {"@id":"ex:s2","p":"ex:o2"}
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+Message 2:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+### WebSocket Subprotocol Negotiation ### {#websocket-subprotocol-negotiation}
+
+Handshake request:
+
+```http
+Sec-WebSocket-Protocol: rdfm.ld-json, rdfm.n-triples
+```
+
+Handshake response:
+
+```http
+Sec-WebSocket-Protocol: rdfm.n-triples
+```
+
+Input frames:
+
+```text
+Frame 1:
+  _:b0 <http://example.org/p> <http://example.org/o1> .
+
+Frame 2:
+  _:b0 <http://example.org/p> <http://example.org/o2> .
+```
+
+Expected result:
+
+```text
+Message 1 contains one triple whose subject is a blank node.
+Message 2 contains one triple whose subject is a blank node.
+The two blank nodes must not be the same RDF term.
+```
+
+### Kafka Records ### {#kafka-records}
+
+Record headers for both records:
+
+```text
+RDF-Message-Content-Type: application/n-triples
+```
+
+Input records:
+
+```text
+Record 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+Record 2:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+Message 2:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+### MQTT 5 Publish Packets ### {#mqtt-5-publish-packets}
+
+PUBLISH properties for both packets:
+
+```text
+Content Type: application/ld+json
+```
+
+Input packets:
+
+```text
+Packet 1 payload:
+  {"@id":"http://example.org/s1","http://example.org/p":{"@id":"http://example.org/o1"}}
+
+Packet 2 payload:
+  {"@id":"http://example.org/s2","http://example.org/p":{"@id":"http://example.org/o2"}}
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+Message 2:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+### Other Broker Messages ### {#other-broker-messages}
+
+Message headers for both broker messages:
+
+```text
+RDF-Message-Content-Type: application/trig
+```
+
+Input broker messages:
+
+```text
+Message 1 body:
+  <http://example.org/g1> {
+    <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+  }
+
+Message 2 body:
+  <http://example.org/g2> {
+    <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+  }
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> <http://example.org/g1> .
+
+Message 2:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> <http://example.org/g2> .
+```
+
+### Jelly gRPC Frames ### {#jelly-grpc-frames}
+
+Input stream:
+
+```text
+RdfStreamFrame 1:
+  RDF dataset containing <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+RdfStreamFrame 2:
+  RDF dataset containing <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+Expected messages:
+
+```text
+Message 1:
+  <http://example.org/s1> <http://example.org/p> <http://example.org/o1> .
+
+Message 2:
+  <http://example.org/s2> <http://example.org/p> <http://example.org/o2> .
+```
+
+### SSE Rejects Direct Binary RDF Payloads ### {#sse-rejects-direct-binary-rdf-payloads}
+
+Stream metadata:
+
+```http
+Content-Type: text/event-stream
+RDF-Message-Content-Type: application/x-jelly-rdf
+```
+
+Expected result:
+
+```text
+The adapter must reject the stream metadata because binary RDF serializations must not be sent directly in SSE data fields.
+```
 
 ## Parsing Tests for Turtle, TriG, N-Triples, and N-Quads ## {#parsing-tests-turtle-trig-n-triples-n-quads}
 

--- a/spec/messages.bs
+++ b/spec/messages.bs
@@ -117,6 +117,161 @@ Issue: Add a diagram illustrating RDF Messages, an RDF Message Stream, stream pr
 
 Issue: Find out and document the similarities/differences to the [RDF-JS Stream interface](https://rdf.js.org/stream-spec/)
 
+## Discovering RDF Message Streams ## {#stream-discovery}
+
+A push-based or message-based channel can advertise that it carries [=RDF Messages=] by declaring the RDF media type of the payload at channel, subscription, or protocol-message level using `RDF-Message-Content-Type` or a protocol-native equivalent.
+
+If a channel is declared to carry [=RDF Messages=], each native protocol message MUST be interpreted as one [=RDF Message=]. Blank node identifiers are scoped to that protocol message only, and RDF data from different protocol messages MUST NOT be merged by default.
+
+For JSON-LD payloads, a channel MAY provide an external JSON-LD context using the JSON-LD context link relation: `Link: &lt;https://example.org/context.jsonld&gt;; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"`. If a stream is identified by an IRI, the linked context for that stream IRI MUST remain stable for the lifetime of that stream.
+
+### Server-Sent Events ### {#sse-live-streams}
+
+A Server-Sent Events stream ([[!EventSource]]) carrying [=RDF Messages=] MUST advertise `Content-Type: text/event-stream`. The producer MUST declare the RDF media type of event payloads using `RDF-Message-Content-Type`. Each SSE event MUST be interpreted as one [=RDF Message=].
+
+The value of `RDF-Message-Content-Type` MUST be an RDF media type for a serialization that can be represented in SSE `data` fields, such as `application/ld+json`, `text/turtle`, `application/trig`, `application/n-triples`, or `application/n-quads`. Binary RDF serializations, such as `application/x-jelly-rdf`, MUST NOT be sent directly in SSE `data` fields.
+
+```http
+RDF-Message-Content-Type: <rdf-media-type>
+```
+
+<div class="example">
+
+```http
+Content-Type: text/event-stream
+Cache-Control: no-cache
+Link: <https://example.org/context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+RDF-Message-Content-Type: application/ld+json
+```
+
+```text
+event: rdf-message
+data: {"@id":"https://example.org/s1","https://example.org/p":"value"}
+```
+
+</div>
+
+### WebSockets ### {#websocket-live-streams}
+
+A WebSocket stream ([[!WebSockets]]) carrying [=RDF Messages=] MUST declare the RDF media type using a `Sec-WebSocket-Protocol` subprotocol token in the opening handshake. A client MAY offer multiple RDF Message subprotocol tokens, each corresponding to a different RDF serialization. The server MUST select one of the offered subprotocol tokens and echo it in the opening handshake response. Each WebSocket message MUST be interpreted as one [=RDF Message=].
+
+The selected subprotocol token determines the RDF media type of all WebSocket messages on that connection:
+
+- `rdfm.ld-json` means `application/ld+json`.
+- `rdfm.turtle` means `text/turtle`.
+- `rdfm.trig` means `application/trig`.
+- `rdfm.n-triples` means `application/n-triples`.
+- `rdfm.n-quads` means `application/n-quads`.
+- `rdfm.jelly` means `application/x-jelly-rdf`.
+
+When the selected RDF serialization is binary, such as `rdfm.jelly`, each [=RDF Message=] MUST be sent as a binary WebSocket message.
+
+```http
+Sec-WebSocket-Protocol: <rdf-message-subprotocol>, ...
+```
+
+<div class="example">
+
+Client handshake request offering JSON-LD and N-Triples:
+
+```http
+GET /stream HTTP/1.1
+Host: example.org
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+Sec-WebSocket-Version: 13
+Sec-WebSocket-Protocol: rdfm.ld-json, rdfm.n-triples
+```
+
+Server handshake response selecting N-Triples:
+
+```http
+HTTP/1.1 101 Switching Protocols
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
+Sec-WebSocket-Protocol: rdfm.n-triples
+```
+
+```text
+WebSocket message:
+<https://example.org/s1> <https://example.org/p> <https://example.org/o1> .
+```
+
+</div>
+
+### Kafka ### {#kafka-live-streams}
+
+A Kafka topic carrying [=RDF Messages=] MUST declare the RDF media type using `RDF-Message-Content-Type` in record headers or topic metadata. Each Kafka record MUST be interpreted as one [=RDF Message=].
+
+The value of `RDF-Message-Content-Type` MUST be an RDF media type.
+
+```text
+RDF-Message-Content-Type: <rdf-media-type>
+```
+
+<div class="example">
+
+```text
+topic: observations
+headers:
+  RDF-Message-Content-Type: application/n-triples
+value:
+  <https://example.org/s1> <https://example.org/p> <https://example.org/o1> .
+```
+
+</div>
+
+### MQTT 5 ### {#mqtt-live-streams}
+
+An MQTT 5 ([[mqtt-5]]) topic carrying [=RDF Messages=] MUST declare the RDF media type using the PUBLISH `Content Type` property. Each MQTT PUBLISH packet MUST be interpreted as one [=RDF Message=].
+
+The value of `Content Type` MUST be an RDF media type.
+
+```text
+Content Type: <rdf-media-type>
+```
+
+<div class="example">
+
+```text
+PUBLISH topic: observations
+Content Type: application/ld+json
+Payload: {"@id":"https://example.org/s1","https://example.org/p":"value"}
+```
+
+</div>
+
+### Other message brokers ### {#message-broker-live-streams}
+
+AMQP, NATS, Pulsar, and similar message brokers carrying [=RDF Messages=] MUST declare the RDF media type using `RDF-Message-Content-Type` in message properties, message headers, stream metadata, or equivalent broker metadata. Each broker message MUST be interpreted as one [=RDF Message=].
+
+The value of `RDF-Message-Content-Type`, or the protocol-native content type property, MUST be an RDF media type.
+
+```text
+RDF-Message-Content-Type: <rdf-media-type>
+```
+
+<div class="example">
+
+```text
+headers:
+  RDF-Message-Content-Type: application/trig
+body:
+  <https://example.org/g> {
+    <https://example.org/s1> <https://example.org/p> <https://example.org/o1> .
+  }
+```
+
+</div>
+
+### Jelly gRPC ### {#jelly-grpc}
+
+See https://jelly-rdf.github.io/dev/specification/streaming/
+
+Every RdfStreamFrame is in fact an RDF Message.
+
 ## RDF Message Logs ## {#rdf-message-logs}
 
 An <dfn>RDF Message Log</dfn> is a static representation of an [=RDF Message Stream=], which can be used for archiving, sharing, and processing the messages in the stream at a later point in time. 
@@ -473,6 +628,8 @@ Issue: Is there a different industry-standard way to serialize multiple RDF/XML 
 ## Other formats ## {#other-formats}
 
 Efficient interchange of [=RDF Message Logs=] may also be done using binary RDF serializations, such as [Jelly](https://w3id.org/jelly/), which already has built-in support for grouping quads into messages. We propose that Jelly and similar formats use the definitions from this specification to define the semantics of RDF Messages.
+
+In Jelly, each RdfStreamFrame is an [=RDF Message=].
 
 # RDF Message Stream Profiles # {#rdf-message-stream-profiles}
 

--- a/spec/messages.bs
+++ b/spec/messages.bs
@@ -268,7 +268,7 @@ body:
 
 ### Jelly gRPC ### {#jelly-grpc}
 
-See https://jelly-rdf.github.io/dev/specification/streaming/
+See https://w3id.org/jelly/dev/specification/streaming/
 
 Every RdfStreamFrame is in fact an RDF Message.
 


### PR DESCRIPTION
This PR adds a concise discovery model for live RDF Message Streams across push-based and message-based protocols. It defines how channels such as SSE, WebSockets, Kafka, MQTT 5, broker systems, and Jelly gRPC can advertise that their native protocol messages carry RDF Messages, primarily through RDF-Message-Content-Type or protocol-native equivalents. This makes message boundaries explicit at the transport level, clarifies that blank node identifiers are scoped per protocol message, and prevents consumers from accidentally merging RDF data across messages. The PR also adds interoperability tests for these live stream discovery mechanisms, including JSON-LD context links, WebSocket serialization negotiation, broker metadata, and Jelly gRPC frames.

Fixes #33 